### PR TITLE
Fix 'make permissions' in prototype

### DIFF
--- a/prototype/Makefile
+++ b/prototype/Makefile
@@ -23,7 +23,7 @@ main.o: main.c
 
 permissions:
 	sudo chmod a+r /sys/class/dmi/id/product_serial
-	lsusb -d 138a: | awk -F '[^0-9]+' '{ print "/dev/bus/usb/" $2 "/" $3 }' | xargs sudo chmod a+rwx 
+	lsusb -d 138a: | awk -F '[^0-9]+' '{ print "/dev/bus/usb/" $$2 "/" $$3 }' | xargs sudo chmod a+rw
  
 clean:
 	rm -rf $(OBJECTS) $(EXECUTABLE) main.o


### PR DESCRIPTION
Fixes using $2 & $3. Removes the unnecessary +x flag