### PR TITLE
added specific instructions for Ubuntu

### DIFF
--- a/prototype/README.md
+++ b/prototype/README.md
@@ -4,6 +4,13 @@ This is a PoC test sandbox for prototyping and testing device communication.
 
 ## Building
 nss, openssl, libpng and libusb are required.
+If you are running *UBUNTU* modify the Makefile adding:
+
+```
+CFLAGS = -c -Wall -g $(pkg-config --cflags glib-2.0 libusb-1.0)
+LDFLAGS = $(pkg-config --libs glib-2.0 libusb-1.0)
+```
+
 ```
 make
 make permissions # Will set required permissions


### PR DESCRIPTION
in ubuntu libs like glib are under specific subfolders. using pkg-config is the right solution