### PR TITLE
Update prototype "permissions" target to set permissions for device 009a

### DIFF
--- a/prototype/Makefile
+++ b/prototype/Makefile
@@ -49,6 +49,7 @@ permissions:
 	sudo chmod a+r /sys/class/dmi/id/product_serial
 	lsusb -d 138a: | awk -F '[^0-9]+' '{ print "/dev/bus/usb/" $$2 "/" $$3 }' | xargs -r sudo chmod a+rw
 	lsusb -d 06cb:0081 | awk -F '[^0-9]+' '{ print "/dev/bus/usb/" $$2 "/" $$3 }' | xargs -r sudo chmod a+rw
+	lsusb -d 06cb:009a | awk -F '[^0-9]+' '{ print "/dev/bus/usb/" $$2 "/" $$3 }' | xargs -r sudo chmod a+rw
 
 clean:
 	rm -f $(OBJECTS) $(OBJECTS_GTEST) $(EXECUTABLE) main.o test/gtest test/gtest.out.*


### PR DESCRIPTION
Currently, running `make permissions` doesn't set the permissions correctly for device 06cb:009a. This change fixes that.