### PR TITLE
Update dissector to work in Wireshark 3

### DIFF
--- a/dissector.lua
+++ b/dissector.lua
@@ -34,7 +34,7 @@ local CONST_MAGIC_HEADER_TLS14 = ByteArray.new("14")
 
 local packetDb = {}
 local partialBuffer = nil
-local sslDissector = Dissector.get('ssl')
+local sslDissector = Dissector.get('tls')
 
 local function decode_aes(ivStr, dataStr)
     -- body


### PR DESCRIPTION
Wireshark 3.0.0 renamed the SSL dissector to TLS.